### PR TITLE
Corrected subtitle level for some global_options; Increased auto generated index depth level by 1.

### DIFF
--- a/en-us/global_options.md
+++ b/en-us/global_options.md
@@ -1793,7 +1793,7 @@ class GraphicRect(
 ```
 
 
-### PolarOpts: polar coordinate system configuration
+## PolarOpts: polar coordinate system configuration
 > *class pyecharts.PolarOpts*
 
 ```python
@@ -1813,7 +1813,7 @@ class PolarOpts(
 )
 ```
 
-### DatasetTransformOpts: dataset transformation configuration items
+## DatasetTransformOpts: dataset transformation configuration items
 > *class pyecharts.options.DatasetTransformOpts*
 
 ```python
@@ -1830,7 +1830,7 @@ class DatasetTransformOpts(
 )
 ```
 
-### EmphasisOpts: polygon and label styles for highlighting.
+## EmphasisOpts: polygon and label styles for highlighting.
 > *class pyecharts.EmphasisOpts*.
 
 ```python

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         autoHeader: true,
         loadSidebar: true,
         loadNavbar: true,
-        subMaxLevel: 2,
+        subMaxLevel: 3,
         auto2top: true,
         homepage: 'zh-cn/README.md',
         search: {

--- a/zh-cn/global_options.md
+++ b/zh-cn/global_options.md
@@ -1704,7 +1704,7 @@ class GraphicRect(
 ```
 
 
-### PolarOpts：极坐标系配置
+## PolarOpts：极坐标系配置
 > *class pyecharts.PolarOpts*
 
 ```python
@@ -1724,7 +1724,7 @@ class PolarOpts(
 )
 ```
 
-### DatasetTransformOpts：数据集转换配置项
+## DatasetTransformOpts：数据集转换配置项
 > *class pyecharts.options.DatasetTransformOpts*
 
 ```python
@@ -1741,7 +1741,7 @@ class DatasetTransformOpts(
 )
 ```
 
-### EmphasisOpts: 高亮状态下的多边形和标签样式。
+## EmphasisOpts: 高亮状态下的多边形和标签样式。
 > *class pyecharts.EmphasisOpts*
 
 ```python


### PR DESCRIPTION
Please note that there are 2 changes in this PR:
1. Corrected the subtitle level for: PolarOpts, DatasetTransformOpts and EmphasisOpts.
2. Could we show a deeper subtitle level in the index? This would decrease the scrolling when searching for specific subtitles for items with many of them, eg pyecharts.GraphicGroup. If this feels too much feel free to revert this change.

https://pyecharts.org/#/en-us/global_options
https://pyecharts.org/#/zh-cn/global_options