### PR TITLE
docs: add marimo

### DIFF
--- a/en-us/intro.md
+++ b/en-us/intro.md
@@ -6,7 +6,7 @@
 
 * Simple API design, silky smooth usage and support for chained calls
 * 30+ common charts in one place
-* Supports major Notebook environments, Jupyter Notebook and JupyterLab
+* Supports major Notebook environments, Jupyter Notebook, JupyterLab, and [marimo](https://github.com/marimo-team/marimo)
 * Easy integration with major web frameworks such as Flask, Django, etc.
 * Highly flexible configuration options for easy matching of beautiful charts
 * Detailed documentation and examples to help developers get up and running faster

--- a/en-us/notebook.md
+++ b/en-us/notebook.md
@@ -81,3 +81,24 @@ bar.render_notebook()
 ```
 
 ![](https://user-images.githubusercontent.com/17564655/60228824-8abb7b80-98c6-11e9-9435-0fc8777624d0.png)
+
+## marimo
+
+[marimo](https://github.com/marimo-team/marimo) automatically renders pyecharts charts in the marimo notebook environment, without any configuration required.
+
+```python
+import pyecharts.options as opts
+from pyecharts.charts import Bar
+
+bar = (
+    Bar()
+    .add_xaxis(["shirt", "cardigan", "chiffon", "pants", "heels", "socks"])
+    .add_yaxis("Merchant A", [5, 20, 36, 10, 75, 90])
+    .add_yaxis("Merchant B", [15, 6, 45, 20, 35, 66])
+    .set_global_opts(title_opts=opts.TitleOpts(title="Main Title", subtitle="Subtitle"))
+)
+
+bar
+```
+
+![](TODO)

--- a/en-us/notebook.md
+++ b/en-us/notebook.md
@@ -101,4 +101,4 @@ bar = (
 bar
 ```
 
-![](TODO)
+![marimo](https://github.com/user-attachments/assets/5270706e-3543-44bb-8478-3058a8a0e54f)

--- a/en-us/quickstart.md
+++ b/en-us/quickstart.md
@@ -122,4 +122,4 @@ bar = (
 
 ### Using Notebook
 
-Of course you can also take a cooler approach and use Notebook to display diagrams. matplotlib has it, so will pyecharts. pyecharts supports Jupyter Notebook / Jupyter Lab / Nteract / Zeppelin for rendering in all four environments. See [Advanced Topics/Notebook](zh-cn/notebook) for details
+Of course you can also take a cooler approach and use Notebook to display diagrams. matplotlib has it, so will pyecharts. pyecharts supports Jupyter Notebook / Jupyter Lab / Nteract / Zeppelin / marimo for rendering in all four environments. See [Advanced Topics/Notebook](zh-cn/notebook) for details


### PR DESCRIPTION
Hi pyecharts team, thank you for such a great library!

I hope the contribution is ok - we have a few users using pyecharts in [marimo](https://github.com/marimo-team/marimo) and would like to let people on your docs know that we support pyecharts natively (with no configuration).

If this is ok with the team, I would love some help with the Chinese docs. 

<img width="1314" alt="marimo" src="https://github.com/user-attachments/assets/5270706e-3543-44bb-8478-3058a8a0e54f">

