### PR TITLE
Version 2.0.9

### DIFF
--- a/en-us/changelog.md
+++ b/en-us/changelog.md
@@ -1,6 +1,19 @@
 # Version log
 
-### version 2.0.8 - 2025-01-24 (Current)
+### version 2.0.9 - 2025-10-10 (Current)
+
+**Updated**
+* Update the way parameters are added to the `Table` class by adding the parameter `**kwargs` to expand other parameters for `Table` to interface with `prettytable`.
+* Update `MarkPointOpts`，`MarkPointItemOpts` and `LabelOpts`.
+* Update `Line` parameter `end_label_opts`
+
+**Fixed**
+* Fix the problem that `chart_id` is not effective in the `Grid` chart scenario.
+* Fix the duplicate configuration problem of `datazoom` and `visualmap` in the generated `HTML` file in the `Grid` chart scenario.
+* Fix several index issues in the `Grid` chart scenario.
+* Fix the abnormal override of css_libs in `Page` chart.
+
+### version 2.0.8 - 2025-01-24
 
 **Added**
 * Added compatibility for Google Maps `GMap`. Refer to `AMap` for usage.

--- a/en-us/rectangular_charts.md
+++ b/en-us/rectangular_charts.md
@@ -955,6 +955,9 @@ def add_yaxis(
 
     # Label configuration items, see `series_options.LabelOpts`
     label_opts: Union[opts.LabelOpts, dict] = opts,
+    
+    # End Label configuration items, see `series_options.LabelOpts`
+    end_label_opts: types.Label = None,
 
     # Line style configuration items, see `series_options.LineStyleOpts`
     linestyle_opts: Union[opts.LineStyleOpts, dict] = opts.LineStyleOpts(),

--- a/zh-cn/changelog.md
+++ b/zh-cn/changelog.md
@@ -1,6 +1,19 @@
 # 版本日志
 
-### version 2.0.8 - 2025-01-24 (Current)
+### version 2.0.9 - 2025-10-10 (Current)
+
+**Updated**
+* 更新 `Table` 类参数添加方式，加入参数 `**kwargs`，扩展 `Table` 对接 `prettytable` 的其他参数。
+* 更新 `MarkPointOpts`、`MarkPointItemOpts` 以及 `LabelOpts`。
+* 更新 `Line`，加入参数 `end_label_opts` 适配。
+
+**Fixed**
+* 修复 `Grid` 图场景下，`chart_id` 不生效的问题。
+* 修复 `Grid` 图场景下，`datazoom` 和 `visualmap` 在生成的 `HTML` 文件中的配置重复问题。
+* 修复 `Grid` 图场景下若干索引问题。
+* 修复 `Page` 的 `css_libs` 被异常覆盖。
+
+### version 2.0.8 - 2025-01-24 
 
 **Added**
 * 增加对于谷歌地图 `GMap` 的兼容，使用方式参考 `AMap`

--- a/zh-cn/rectangular_charts.md
+++ b/zh-cn/rectangular_charts.md
@@ -957,6 +957,9 @@ def add_yaxis(
 
     # 标签配置项，参考 `series_options.LabelOpts`
     label_opts: Union[opts.LabelOpts, dict] = opts.LabelOpts(),
+    
+    # 端点配置项，参考 `series_options.LabelOpts`
+    end_label_opts: types.Label = None,
 
     # 线样式配置项，参考 `series_options.LineStyleOpts`
     linestyle_opts: Union[opts.LineStyleOpts, dict] = opts.LineStyleOpts(),


### PR DESCRIPTION
**Updated**
* 更新 `Table` 类参数添加方式，加入参数 `**kwargs`，扩展 `Table` 对接 `prettytable` 的其他参数。
* 更新 `MarkPointOpts`、`MarkPointItemOpts` 以及 `LabelOpts`。
* 更新 `Line`，加入参数 `end_label_opts` 适配。

**Fixed**
* 修复 `Grid` 图场景下，`chart_id` 不生效的问题。
* 修复 `Grid` 图场景下，`datazoom` 和 `visualmap` 在生成的 `HTML` 文件中的配置重复问题。
* 修复 `Grid` 图场景下若干索引问题。
* 修复 `Page` 的 `css_libs` 被异常覆盖。

---

**Updated**
* Update the way parameters are added to the `Table` class by adding the parameter `**kwargs` to expand other parameters for `Table` to interface with `prettytable`.
* Update `MarkPointOpts`，`MarkPointItemOpts` and `LabelOpts`.
* Update `Line` parameter `end_label_opts`

**Fixed**
* Fix the problem that `chart_id` is not effective in the `Grid` chart scenario.
* Fix the duplicate configuration problem of `datazoom` and `visualmap` in the generated `HTML` file in the `Grid` chart scenario.
* Fix several index issues in the `Grid` chart scenario.
* Fix the abnormal override of css_libs in `Page` chart.