### PR TITLE
docs: Fix Python code block syntax in documentation

### DIFF
--- a/en-us/themes.md
+++ b/en-us/themes.md
@@ -25,7 +25,7 @@ def theme_default() -> Bar:
 
 ### LIGHT
 
-```pyhon
+```python
 c = Bar(init_opts=opts.InitOpts(theme=ThemeType.LIGHT))
 ```
 ![](https://user-images.githubusercontent.com/19553554/55897092-6cf94700-5bf2-11e9-8fa9-e7d880481a90.png)

--- a/zh-cn/themes.md
+++ b/zh-cn/themes.md
@@ -26,7 +26,7 @@ def theme_default() -> Bar:
 
 ### LIGHT
 
-```pyhon
+```python
 c = Bar(init_opts=opts.InitOpts(theme=ThemeType.LIGHT))
 ```
 ![](https://user-images.githubusercontent.com/19553554/55897092-6cf94700-5bf2-11e9-8fa9-e7d880481a90.png)


### PR DESCRIPTION
## 描述
修复文档中 Python 代码块的语法高亮问题。

## 修改内容
- 将 `pyhon` 更正为 `python`
- 确保代码块能够正确高亮显示

## 说明
本次修改仅涉及文档格式修正，不涉及任何代码逻辑变更。修正后代码块能够正确语法高亮，提升文档可读性。